### PR TITLE
Fixed data type ignored at writing to file

### DIFF
--- a/ldparser.py
+++ b/ldparser.py
@@ -119,7 +119,7 @@ class ldData(object):
             self.head.write(f_, len(self.channs))
             f_.seek(self.channs[0].meta_ptr)
             list(map(lambda c: c[1].write(f_, c[0]), enumerate(self.channs)))
-            list(map(lambda c: f_.write(conv_data(c)), self.channs))
+            list(map(lambda c: f_.write(conv_data(c).astype(c.dtype)), self.channs))
 
 
 class ldEvent(object):


### PR DESCRIPTION
Data is always stored float64 internally, so it needs to be set to the right data type of the header before written to file